### PR TITLE
JCN-180-FIX-VALIDACIÓN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
+### Added
+- valid `event.id` and `event.client` test cases
+
+### Fixed
+- `event.id` validations
 
 ## [2.0.0] - 2019-10-21
 ### Changed

--- a/lib/event-emitter.js
+++ b/lib/event-emitter.js
@@ -49,7 +49,7 @@ class EventEmitter {
 			throw new EventEmitterError('Invalid event: client property must be a string', EventEmitterError.codes.INVALID_EVENT_PROPERTIES);
 
 		// If id property exists it must be a string or number
-		if(typeof event.id !== 'undefined' && typeof event.client !== 'string' && typeof event.client !== 'number')
+		if(typeof event.id !== 'undefined' && typeof event.id !== 'string' && typeof event.id !== 'number')
 			throw new EventEmitterError('Invalid event: id property must be a string or number', EventEmitterError.codes.INVALID_EVENT_PROPERTIES);
 	}
 

--- a/tests/event-emitter-test.js
+++ b/tests/event-emitter-test.js
@@ -85,6 +85,44 @@ describe('EventEmitter', () => {
 
 		});
 
+		it('Should call MicroserviceCall.post when the received event.client and event.id are valid', async () => {
+
+			const msCallMock = sinon.mock(MicroserviceCall.prototype);
+
+			['some-id', 1].forEach(async id => {
+
+				const event = {
+					id,
+					client: 'some-client',
+					entity: 'some-entity',
+					event: 'some-event',
+					service: 'some-service'
+				};
+
+				msCallMock.expects('post')
+					.withExactArgs('events', 'event', 'emit', { ...event })
+					.returns({
+						statusCode: 200,
+						body: {
+							id
+						}
+					});
+
+				assert.deepStrictEqual(await EventEmitter.emit(event), {
+					result: true,
+					response: {
+						statusCode: 200,
+						body: {
+							id
+						}
+					}
+				});
+
+				msCallMock.verify();
+			});
+
+		});
+
 		it('Should return true when MicroserviceCall.post responses with status code 200', async () => {
 
 			const event = {

--- a/tests/event-emitter-test.js
+++ b/tests/event-emitter-test.js
@@ -120,7 +120,68 @@ describe('EventEmitter', () => {
 
 				msCallMock.verify();
 			});
+		});
 
+		it('Should call MicroserviceCall.post when the received event has no client but id', async () => {
+
+			const event = {
+				id: 'some-id',
+				entity: 'some-entity',
+				event: 'some-event',
+				service: 'some-service'
+			};
+
+			const msCallMock = sinon.mock(MicroserviceCall.prototype).expects('post')
+				.withExactArgs('events', 'event', 'emit', { ...event })
+				.returns({
+					statusCode: 200,
+					body: {
+						id: event.id
+					}
+				});
+
+			assert.deepStrictEqual(await EventEmitter.emit(event), {
+				result: true,
+				response: {
+					statusCode: 200,
+					body: {
+						id: event.id
+					}
+				}
+			});
+
+			msCallMock.verify();
+		});
+
+		it('Should call MicroserviceCall.post when the received event has no id but client', async () => {
+
+			const event = {
+				client: 'some-client',
+				entity: 'some-entity',
+				event: 'some-event',
+				service: 'some-service'
+			};
+
+			const msCallMock = sinon.mock(MicroserviceCall.prototype).expects('post')
+				.withExactArgs('events', 'event', 'emit', { ...event })
+				.returns({
+					statusCode: 200,
+					body: {
+						id: 'the-event-id'
+					}
+				});
+
+			assert.deepStrictEqual(await EventEmitter.emit(event), {
+				result: true,
+				response: {
+					statusCode: 200,
+					body: {
+						id: 'the-event-id'
+					}
+				}
+			});
+
+			msCallMock.verify();
 		});
 
 		it('Should return true when MicroserviceCall.post responses with status code 200', async () => {


### PR DESCRIPTION
**JCN-180-FIX-VALIDACIÓN**
JCN-180 Package event-emitter no valida el id y el client correctamente

**LINK AL TICKET**
https://fizzmod.atlassian.net/browse/JCN-180

**DESCRIPCIÓN DEL REQUERIMIENTO**
- En la validación del evento, al enviar el dato id y/o client no se valida correctamente y siempre falla.
- Arreglar validación y tests.

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se corrigieron las validaciones del event y se añadieron casos de test cuando los datos recibidos son validos.