### PR TITLE
fix support for array ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Fix `event.id` array validation
 
 ## [2.2.0] - 2021-02-18
 ### Added

--- a/lib/event-emitter.js
+++ b/lib/event-emitter.js
@@ -50,9 +50,11 @@ class EventEmitter {
 
 		// If id property exists it must be a string or number or array of strings or numbers
 		if(typeof event.id !== 'undefined') {
-			if(Array.isArray(event.id) && !event.id.every(id => this.validateId(id)))
+
+			if(Array.isArray(event.id) && (!event.id.length || !event.id.every(id => this.validateId(id))))
 				throw new EventEmitterError('Invalid event: id property must be a array of strings or numbers', EventEmitterError.codes.INVALID_EVENT_PROPERTIES);
-			else if(!this.validateId(event.id))
+
+			if(!Array.isArray(event.id) && !this.validateId(event.id))
 				throw new EventEmitterError('Invalid event: id property must be a string or number', EventEmitterError.codes.INVALID_EVENT_PROPERTIES);
 		}
 	}

--- a/tests/event-emitter-test.js
+++ b/tests/event-emitter-test.js
@@ -99,10 +99,10 @@ describe('EventEmitter', () => {
 
 			const msCallMock = sinon.mock(MicroserviceCall.prototype);
 
-			['605e72c6e0cfb95fb0884adb', true].forEach(async id => {
+			['605e72c6e0cfb95fb0884adb', 1].forEach(async id => {
 
 				const event = {
-					id: ['605e72c6e0cfb95fb0884adb', true],
+					id,
 					client: 'some-client',
 					entity: 'some-entity',
 					event: 'some-event',

--- a/tests/event-emitter-test.js
+++ b/tests/event-emitter-test.js
@@ -99,10 +99,10 @@ describe('EventEmitter', () => {
 
 			const msCallMock = sinon.mock(MicroserviceCall.prototype);
 
-			['some-id', 1].forEach(async id => {
+			['605e72c6e0cfb95fb0884adb', true].forEach(async id => {
 
 				const event = {
-					id,
+					id: ['605e72c6e0cfb95fb0884adb', true],
 					client: 'some-client',
 					entity: 'some-entity',
 					event: 'some-event',


### PR DESCRIPTION
hotfix para soportar un array de ids

se estaba validando bien el array pero entraba en otro condicional que terminaba arrojando un error